### PR TITLE
feat: remove BcApiChefOptions and implement retry configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,86 @@ const result = await client
         schema: NarrowSchema,
     });
 ```
+
+## Retry Logic
+
+Every data-returning method accepts an optional `retries` key inside its
+options object. When provided, failed requests are automatically retried by the
+underlying HTTP layer ([tchef](https://github.com/rogerio-romao/tchef)).
+
+### RetryConfig shape
+
+```ts
+interface RetryConfig {
+    /** Number of additional retries after the initial attempt. Total calls = repeat + 1. */
+    repeat: number;
+    /**
+     * Delay between retries.
+     * - number — fixed delay in milliseconds (e.g. 500 → 500 ms between each retry).
+     * - 'exponential' — exponential back-off: 2000 × 2^(attempt+1) ms
+     *   (1st retry: 4 000 ms, 2nd: 8 000 ms, 3rd: 16 000 ms …).
+     * Omitting this field uses a 100 ms fixed default.
+     */
+    retryDelay?: number | 'exponential';
+}
+```
+
+Retries are triggered on:
+
+- Non-2xx HTTP responses
+- Invalid / unparseable response bodies (JSON, text, blob)
+- Network errors and request timeouts
+
+When all retries are exhausted the method returns:
+
+```ts
+{ ok: false, statusCode: <last HTTP status>, error: 'Max retries reached. <last error message>' }
+```
+
+### Example — fixed delay in milliseconds
+
+```ts
+const client = new BcApiChef(storeHash, accessToken);
+
+const result = await client
+    .v3()
+    .products()
+    .getOne(123, {
+        retries: { repeat: 3, retryDelay: 500 }, // up to 4 total attempts, 500 ms apart
+    });
+
+if (!result.ok) {
+    console.error(result.error); // 'Max retries reached. ...' if all attempts failed
+} else {
+    console.log(result.data.name);
+}
+```
+
+### Example — exponential back-off
+
+```ts
+const result = await client
+    .v3()
+    .products()
+    .create(
+        { name: 'New Product', type: 'physical', weight: 1.0 },
+        {
+            retries: {
+                repeat: 4,
+                retryDelay: 'exponential', // 4 s → 8 s → 16 s → 32 s
+            },
+        },
+    );
+```
+
+### Example — retries on sub-resources
+
+```ts
+const result = await client
+    .v3()
+    .products()
+    .images(42)
+    .getMultiple({
+        retries: { repeat: 2, retryDelay: 1000 },
+    });
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bc-api-chef",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "Node application to serve the BigCommerce API",
     "license": "ISC",
     "author": "Rogerio Romao",

--- a/src/BcApiChef.ts
+++ b/src/BcApiChef.ts
@@ -1,7 +1,5 @@
 import V3Api from './v3Api/V3Api.ts';
 
-import type { BcApiChefOptions } from '@/types/api-types';
-
 const BC_API_BASE_URL = 'https://api.bigcommerce.com/stores';
 
 /**
@@ -13,21 +11,19 @@ const BC_API_BASE_URL = 'https://api.bigcommerce.com/stores';
  * ```ts
  * import { BcApiChef } from 'bc-api-chef';
  *
- * const bc = new BcApiChef(storeHash, accessToken, { retries: 3 });
- * const result = await bc.v3().products().getAllProducts();
+ * const bc = new BcApiChef(storeHash, accessToken);
+ * const result = await bc.v3().products().getOne(42);
  * if (result.ok) {
  *   console.log(result.data);
  * }
  * ```
  * Currently exposes the V3 API namespace via {@link BcApiChef.v3}. Each call
- * to `.v3()` returns a fresh `V3Api` instance that shares the same access
- * token, base URL, and options.
+ * to `.v3()` returns a fresh `V3Api` instance bound to the same access token
+ * and base URL.
  */
 export default class BcApiChef {
     private accessToken: string;
     private baseUrl: string;
-    /** The `Required` here makes typescript happy without having to check for undefined values upstream constantly, but the values are still optional at runtime */
-    private options: Required<BcApiChefOptions>;
 
     /**
      * Creates a new `BcApiChef` client bound to a specific BigCommerce store.
@@ -37,20 +33,10 @@ export default class BcApiChef {
      * `https://api.bigcommerce.com/stores/{store_hash}`).
      * @param accessToken - BigCommerce API access token, sent as the `X-Auth-Token`
      * header on every request.
-     * @param options     - Optional client-wide behaviour toggles. All fields default
-     * to a safe value so existing callers are unaffected.
-     * @param options.retries  - Number of times to retry a failed HTTP request before
-     * surfacing the error. Forwarded to the underlying `tchef` HTTP client.
-     * Defaults to `0` (no retries).
-     * @todo `options.retries` is not yet forwarded to `tchef()` calls in `ProductsV3`.
      */
-    constructor(storeHash: string, accessToken: string, options: BcApiChefOptions = {}) {
+    constructor(storeHash: string, accessToken: string) {
         this.accessToken = accessToken;
         this.baseUrl = `${BC_API_BASE_URL}/${storeHash}`;
-        this.options = {
-            retries: 0,
-            ...options,
-        };
     }
 
     /**
@@ -60,6 +46,6 @@ export default class BcApiChef {
      * @returns {V3Api} A new `V3Api` instance bound to this client configuration.
      */
     public v3(): V3Api {
-        return new V3Api(this.baseUrl, this.accessToken, this.options);
+        return new V3Api(this.baseUrl, this.accessToken);
     }
 }

--- a/src/tests/unit/helpers.ts
+++ b/src/tests/unit/helpers.ts
@@ -13,6 +13,8 @@ interface MockTchefCallOptions {
     headers?: Record<string, string>;
     method?: string;
     responseFormat?: string;
+    retries?: number;
+    retryDelayMs?: number | 'exponential';
 }
 
 interface MockPageResponse {

--- a/src/tests/unit/products/product-bulk-pricing-rules.test.ts
+++ b/src/tests/unit/products/product-bulk-pricing-rules.test.ts
@@ -42,7 +42,7 @@ describe('ProductBulkPricingRules class', () => {
 
     beforeEach(() => {
         mockTchef.mockReset();
-        bulkPricingRules = new ProductBulkPricingRules('test-token', BASE_URL, {});
+        bulkPricingRules = new ProductBulkPricingRules('test-token', BASE_URL);
     });
 
     // oxlint-disable-next-line max-statements
@@ -918,6 +918,19 @@ describe('ProductBulkPricingRules class', () => {
 
             assertErr(result);
             expect(result.statusCode).toBe(404);
+        });
+    });
+
+    describe('retries forwarding', () => {
+        it('passes retries and retryDelayMs to the underlying HTTP call', async () => {
+            mockTchef.mockResolvedValue(mockRuleEnvelope);
+
+            await bulkPricingRules.getOne(42, 7, { retries: { repeat: 2, retryDelay: 0 } });
+
+            const opts = getCallOptions(mockTchef, 0);
+
+            expect(opts.retries).toBe(2);
+            expect(opts.retryDelayMs).toBe(0);
         });
     });
 });

--- a/src/tests/unit/products/product-custom-fields.test.ts
+++ b/src/tests/unit/products/product-custom-fields.test.ts
@@ -40,7 +40,7 @@ describe('ProductCustomFields class', () => {
 
     beforeEach(() => {
         mockTchef.mockReset();
-        customFields = new ProductCustomFields('test-token', BASE_URL, {});
+        customFields = new ProductCustomFields('test-token', BASE_URL);
     });
 
     describe('get one custom field', () => {
@@ -557,6 +557,19 @@ describe('ProductCustomFields class', () => {
 
             assertErr(result);
             expect(result.statusCode).toBe(404);
+        });
+    });
+
+    describe('retries forwarding', () => {
+        it('passes retries and retryDelayMs to the underlying HTTP call', async () => {
+            mockTchef.mockResolvedValue(mockCustomFieldEnvelope);
+
+            await customFields.getOne(42, 55, { retries: { repeat: 2, retryDelay: 0 } });
+
+            const opts = getCallOptions(mockTchef, 0);
+
+            expect(opts.retries).toBe(2);
+            expect(opts.retryDelayMs).toBe(0);
         });
     });
 });

--- a/src/tests/unit/products/product-images.test.ts
+++ b/src/tests/unit/products/product-images.test.ts
@@ -50,7 +50,7 @@ describe('ProductImages class', () => {
 
     beforeEach(() => {
         mockTchef.mockReset();
-        images = new ProductImages('test-token', BASE_URL, {});
+        images = new ProductImages('test-token', BASE_URL);
     });
 
     afterEach(() => {
@@ -874,6 +874,22 @@ describe('ProductImages class', () => {
                 assertErr(result);
                 expect(result.statusCode).toBe(404);
             });
+        });
+    });
+
+    describe('retries forwarding', () => {
+        it('passes retries and retryDelayMs to the underlying HTTP call', async () => {
+            mockTchef.mockResolvedValue({
+                data: { data: mockImage },
+                ok: true,
+            });
+
+            await images.getOne(42, 55, { retries: { repeat: 3, retryDelay: 0 } });
+
+            const opts = getCallOptions(mockTchef, 0);
+
+            expect(opts.retries).toBe(3);
+            expect(opts.retryDelayMs).toBe(0);
         });
     });
 });

--- a/src/tests/unit/products/product-metafields.test.ts
+++ b/src/tests/unit/products/product-metafields.test.ts
@@ -48,7 +48,7 @@ describe('ProductMetafields class', () => {
 
     beforeEach(() => {
         mockTchef.mockReset();
-        metafields = new ProductMetafields('test-token', BASE_URL, {});
+        metafields = new ProductMetafields('test-token', BASE_URL);
     });
 
     describe('get one metafield', () => {
@@ -839,6 +839,19 @@ describe('ProductMetafields class', () => {
 
             assertErr(result);
             expect(result.statusCode).toBe(404);
+        });
+    });
+
+    describe('retries forwarding', () => {
+        it('passes retries and retryDelayMs to the underlying HTTP call', async () => {
+            mockTchef.mockResolvedValue(mockMetafieldEnvelope);
+
+            await metafields.getOne(42, 99, { retries: { repeat: 2, retryDelay: 0 } });
+
+            const opts = getCallOptions(mockTchef, 0);
+
+            expect(opts.retries).toBe(2);
+            expect(opts.retryDelayMs).toBe(0);
         });
     });
 });

--- a/src/tests/unit/products/products-v3.test.ts
+++ b/src/tests/unit/products/products-v3.test.ts
@@ -29,11 +29,7 @@ describe('ProductsV3 class', () => {
 
     beforeEach(() => {
         mockTchef.mockReset();
-        products = new ProductsV3(
-            'https://api.bigcommerce.com/stores/test-hash/v3/',
-            'test-token',
-            {},
-        );
+        products = new ProductsV3('https://api.bigcommerce.com/stores/test-hash/v3/', 'test-token');
     });
 
     describe('get product', () => {
@@ -1018,6 +1014,22 @@ describe('ProductsV3 class', () => {
             assertErr(result);
             expect(result.statusCode).toBe(404);
             expect(result.error).toBe('Not Found');
+        });
+    });
+
+    describe('retries forwarding', () => {
+        it('passes retries and retryDelayMs to the underlying HTTP call', async () => {
+            mockTchef.mockResolvedValue({
+                data: { data: { id: 42, name: 'Widget' } },
+                ok: true,
+            });
+
+            await products.getOne(42, { retries: { repeat: 2, retryDelay: 0 } });
+
+            const opts = getCallOptions(mockTchef, 0);
+
+            expect(opts.retries).toBe(2);
+            expect(opts.retryDelayMs).toBe(0);
         });
     });
 });

--- a/src/tests/unit/query-serialization.test.ts
+++ b/src/tests/unit/query-serialization.test.ts
@@ -14,7 +14,7 @@ describe('query param serialization', () => {
     beforeEach(() => {
         mockTchef.mockReset();
         mockTchef.mockResolvedValue(makePageResponse());
-        products = new ProductsV3('https://api.bigcommerce.com/stores/test/v3/', 'test-token', {});
+        products = new ProductsV3('https://api.bigcommerce.com/stores/test/v3/', 'test-token');
     });
 
     describe('number array params', () => {

--- a/src/tests/unit/retries.test.ts
+++ b/src/tests/unit/retries.test.ts
@@ -1,0 +1,93 @@
+// oxlint-disable max-lines-per-function
+
+import { assertErr, assertOk } from '@/tests/unit/helpers.ts';
+import ProductsV3 from '@/v3Api/Products/Products';
+
+const BASE_URL = 'https://api.bigcommerce.com/stores/test-hash/v3/';
+
+function makeJsonResponse(body: unknown, status = 200): Response {
+    // oxlint-disable-next-line unicorn/prefer-response-static-json
+    return new Response(JSON.stringify(body), {
+        headers: { 'Content-Type': 'application/json' },
+        status,
+    });
+}
+
+function makeSuccessEnvelope(): Response {
+    return makeJsonResponse({ data: { id: 42, name: 'Widget' }, meta: {} });
+}
+
+describe('retry behaviour (real tchef, stubbed fetch)', () => {
+    let products: ProductsV3;
+
+    beforeEach(() => {
+        vi.unstubAllGlobals();
+        products = new ProductsV3(BASE_URL, 'test-token');
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('succeeds after transient failures within the retry budget', async () => {
+        const mockFetch = vi
+            .fn()
+            .mockResolvedValueOnce(makeJsonResponse({ title: 'Internal Server Error' }, 500))
+            .mockResolvedValueOnce(makeJsonResponse({ title: 'Internal Server Error' }, 500))
+            .mockResolvedValueOnce(makeSuccessEnvelope());
+
+        vi.stubGlobal('fetch', mockFetch);
+
+        const result = await products.getOne(42, {
+            retries: { repeat: 2, retryDelay: 0 },
+        });
+
+        assertOk(result);
+        expect(result.data.id).toBe(42);
+        expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('returns an error result when all retries are exhausted', async () => {
+        const mockFetch = vi
+            .fn()
+            .mockResolvedValue(makeJsonResponse({ title: 'Service Unavailable' }, 503));
+
+        vi.stubGlobal('fetch', mockFetch);
+
+        const result = await products.getOne(42, {
+            retries: { repeat: 2, retryDelay: 0 },
+        });
+
+        assertErr(result);
+        expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('makes exactly one call when repeat is 0', async () => {
+        const mockFetch = vi.fn().mockResolvedValue(makeSuccessEnvelope());
+
+        vi.stubGlobal('fetch', mockFetch);
+
+        const result = await products.getOne(42, {
+            retries: { repeat: 0 },
+        });
+
+        assertOk(result);
+        expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    it('forwards retryDelay to tchef and does not crash', async () => {
+        const mockFetch = vi
+            .fn()
+            .mockResolvedValueOnce(makeJsonResponse({ title: 'Bad Gateway' }, 502))
+            .mockResolvedValueOnce(makeSuccessEnvelope());
+
+        vi.stubGlobal('fetch', mockFetch);
+
+        const result = await products.getOne(42, {
+            retries: { repeat: 1, retryDelay: 0 },
+        });
+
+        assertOk(result);
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/types/api-types.ts
+++ b/src/types/api-types.ts
@@ -1,5 +1,6 @@
-export interface BcApiChefOptions {
-    retries?: number;
+export interface RetryConfig {
+    repeat: number;
+    retryDelay?: number | 'exponential';
 }
 
 export interface StandardSchemaIssue {

--- a/src/types/api-types.ts
+++ b/src/types/api-types.ts
@@ -1,5 +1,22 @@
 export interface RetryConfig {
+    /**
+     * Number of **additional** retries after the initial attempt.
+     * Total network calls = `repeat + 1`.
+     * Must be a positive integer; `0` disables retries (single attempt).
+     */
     repeat: number;
+    /**
+     * Delay strategy between retries.
+     *
+     * - **`number`** — fixed delay in **milliseconds** (e.g. `500` waits 500 ms before each retry).
+     *   Values ≤ 0 are treated as no delay.
+     * - **`'exponential'`** — exponential back-off computed by tchef as `2000 × 2^(attempt + 1)` ms:
+     *   - 1st retry: 4 000 ms
+     *   - 2nd retry: 8 000 ms
+     *   - 3rd retry: 16 000 ms … (no built-in cap)
+     *
+     * Omitting this field uses the tchef default of **100 ms** fixed delay.
+     */
     retryDelay?: number | 'exponential';
 }
 

--- a/src/v3Api/Products/ProductBulkPricingRules.ts
+++ b/src/v3Api/Products/ProductBulkPricingRules.ts
@@ -9,7 +9,7 @@ import {
     validatePositiveIntegers,
 } from '@/v3Api/utils';
 
-import type { ApiResult, BcApiChefOptions, StandardSchemaV1 } from '@/types/api-types';
+import type { ApiResult, RetryConfig, StandardSchemaV1 } from '@/types/api-types';
 import type {
     NoIdProductBulkPricingRule,
     ProductBulkPricingRule,
@@ -31,24 +31,16 @@ import type {
 export default class ProductBulkPricingRules {
     private accessToken: string;
     private apiUrl: string;
-    private options: Required<BcApiChefOptions>;
 
     /**
      * Creates an instance of the ProductBulkPricingRules class.
      *
      * @param accessToken - The BigCommerce API access token to use for requests.
-     * @param apiUrl - The base URL for product-related API endpoints, which should be provided by the parent Products class.
-     * @param options - Optional configuration for API requests, such as retry behavior.
-     * @param options.retries Number of times to retry a failed HTTP request before surfacing the error. Forwarded to the underlying `tchef` HTTP client. Defaults to `0` (no retries).
-     * @todo Forward `this.options.retries` to every `tchef()` call in this class.
+     * @param apiUrl - The base URL for product-related API endpoints.
      */
-    constructor(accessToken: string, apiUrl: string, options: BcApiChefOptions = {}) {
+    constructor(accessToken: string, apiUrl: string) {
         this.accessToken = accessToken;
         this.apiUrl = apiUrl;
-        this.options = {
-            retries: 0,
-            ...options,
-        };
     }
 
     /* -------------------------------------------------------------------------- */
@@ -67,7 +59,7 @@ export default class ProductBulkPricingRules {
     public async create(
         productId: number,
         ruleData: NoIdProductBulkPricingRule,
-        options?: { schema?: StandardSchemaV1 },
+        options?: { schema?: StandardSchemaV1; retries?: RetryConfig },
     ): ApiResult<ProductBulkPricingRule> {
         const idsValidOrErrorMsg = validatePositiveIntegers({ productId });
 
@@ -91,7 +83,13 @@ export default class ProductBulkPricingRules {
 
         const url = `${this.apiUrl}/${productId}/bulk-pricing-rules`;
 
-        return await createResource(url, this.accessToken, ruleData, options?.schema);
+        return await createResource(
+            url,
+            this.accessToken,
+            ruleData,
+            options?.schema,
+            options?.retries,
+        );
     }
     /**
      * Retrieves multiple bulk pricing rules for a product, with optional pagination and field selection. You can use `page` and `limit` query parameters for pagination.
@@ -117,6 +115,7 @@ export default class ProductBulkPricingRules {
             page?: number;
             limit?: number;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<Pick<ProductBulkPricingRule, 'id' | I[number]>[]>;
 
@@ -128,6 +127,7 @@ export default class ProductBulkPricingRules {
             page?: number;
             limit?: number;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<Omit<ProductBulkPricingRule, E[number]>[]>;
 
@@ -137,6 +137,7 @@ export default class ProductBulkPricingRules {
             page?: number;
             limit?: number;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<ProductBulkPricingRule[]>;
 
@@ -148,6 +149,7 @@ export default class ProductBulkPricingRules {
             page?: number;
             limit?: number;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<ProductBulkPricingRule[]> {
         const idsValidOrErrorMsg = validatePositiveIntegers({ productId });
@@ -171,6 +173,7 @@ export default class ProductBulkPricingRules {
             limit,
             queryOptions.page,
             schema,
+            options?.retries,
         );
     }
 
@@ -196,6 +199,7 @@ export default class ProductBulkPricingRules {
             include_fields?: I;
             exclude_fields?: never;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<Pick<ProductBulkPricingRule, 'id' | I[number]>>;
 
@@ -206,6 +210,7 @@ export default class ProductBulkPricingRules {
             include_fields?: never;
             exclude_fields?: E;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<Omit<ProductBulkPricingRule, E[number]>>;
 
@@ -216,6 +221,7 @@ export default class ProductBulkPricingRules {
             include_fields?: readonly ProductBulkPricingRuleField[];
             exclude_fields?: readonly ProductBulkPricingRuleField[];
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<ProductBulkPricingRule> {
         const idsValidOrErrorMsg = validatePositiveIntegers({ productId, ruleId });
@@ -232,7 +238,12 @@ export default class ProductBulkPricingRules {
         const querySuffix = buildQueryString(queryOptions);
         const url = `${this.apiUrl}/${productId}/bulk-pricing-rules/${ruleId}${querySuffix}`;
 
-        return await fetchOne<ProductBulkPricingRule>(url, this.accessToken, schema);
+        return await fetchOne<ProductBulkPricingRule>(
+            url,
+            this.accessToken,
+            schema,
+            options?.retries,
+        );
     }
 
     /* ---------------------- UPDATE PRODUCT BULK PRICING RULE --------------------- */
@@ -244,13 +255,14 @@ export default class ProductBulkPricingRules {
      * @param ruleData - The data to update for the bulk pricing rule. All fields are optional.
      * @param options - Optional. Pass `schema` to validate the returned data against a Standard Schema.
      * @param options.schema - A Standard Schema to validate the API response against. If validation fails, the method will return a 422 error with details about the validation failure.
+     * @param options.retries - Optional retry configuration to automatically retry the request on transient errors.
      * @returns {ApiResult<ProductBulkPricingRule>} The updated bulk pricing rule, or an error if validation fails or the API request fails.
      */
     public async update(
         productId: number,
         ruleId: number,
         ruleData: Partial<NoIdProductBulkPricingRule>,
-        options?: { schema?: StandardSchemaV1 },
+        options?: { schema?: StandardSchemaV1; retries?: RetryConfig },
     ): ApiResult<ProductBulkPricingRule> {
         const idsValidOrErrorMsg = validatePositiveIntegers({ productId, ruleId });
 
@@ -274,7 +286,13 @@ export default class ProductBulkPricingRules {
 
         const url = `${this.apiUrl}/${productId}/bulk-pricing-rules/${ruleId}`;
 
-        return await updateResource(url, this.accessToken, ruleData, options?.schema);
+        return await updateResource(
+            url,
+            this.accessToken,
+            ruleData,
+            options?.schema,
+            options?.retries,
+        );
     }
 
     /* ---------------------- DELETE PRODUCT BULK PRICING RULE --------------------- */
@@ -283,9 +301,15 @@ export default class ProductBulkPricingRules {
      *
      * @param productId - The ID of the product the bulk pricing rule belongs to.
      * @param ruleId - The ID of the bulk pricing rule to delete.
+     * @param options - Optional parameters.
+     * @param options.retries - Optional retry configuration to automatically retry the request on transient errors.
      * @returns {ApiResult<null>} An empty result if deletion is successful, or an error if validation fails or the API request fails.
      */
-    public async remove(productId: number, ruleId: number): ApiResult<null> {
+    public async remove(
+        productId: number,
+        ruleId: number,
+        options?: { retries?: RetryConfig },
+    ): ApiResult<null> {
         const idsValidOrErrorMsg = validatePositiveIntegers({ productId, ruleId });
 
         if (idsValidOrErrorMsg !== true) {
@@ -298,7 +322,7 @@ export default class ProductBulkPricingRules {
 
         const url = `${this.apiUrl}/${productId}/bulk-pricing-rules/${ruleId}`;
 
-        return await deleteResource(url, this.accessToken);
+        return await deleteResource(url, this.accessToken, options?.retries);
     }
 
     /* -------------------------------------------------------------------------- */

--- a/src/v3Api/Products/ProductCustomFields.ts
+++ b/src/v3Api/Products/ProductCustomFields.ts
@@ -9,7 +9,7 @@ import {
     validatePositiveIntegers,
 } from '@/v3Api/utils.ts';
 
-import type { ApiResult, BcApiChefOptions, StandardSchemaV1 } from '@/types/api-types';
+import type { ApiResult, RetryConfig, StandardSchemaV1 } from '@/types/api-types';
 import type {
     NoIdProductCustomField,
     ProductCustomField,
@@ -33,24 +33,16 @@ import type {
 export default class ProductCustomFields {
     private accessToken: string;
     private apiUrl: string;
-    private options: Required<BcApiChefOptions>;
 
     /**
      * Creates an instance of the ProductCustomFields class.
      *
      * @param accessToken - The access token for authenticating API requests.
-     * @param apiUrl - The base URL for the product custom fields API endpoints, typically in the format `${baseUrlWithVersion}/products`.
-     * @param options - Optional configuration options for the API client, such as retry settings.
-     * @param options.retries Number of times to retry a failed HTTP request before surfacing the error. Forwarded to the underlying `tchef` HTTP client. Defaults to `0` (no retries).
-     * @todo Forward `this.options.retries` to every `tchef()` call in this class.
+     * @param apiUrl - The base URL for the product custom fields API endpoints.
      */
-    constructor(accessToken: string, apiUrl: string, options: BcApiChefOptions = {}) {
+    constructor(accessToken: string, apiUrl: string) {
         this.accessToken = accessToken;
         this.apiUrl = apiUrl;
-        this.options = {
-            retries: 0,
-            ...options,
-        };
     }
 
     /* -------------------------------------------------------------------------- */
@@ -70,7 +62,7 @@ export default class ProductCustomFields {
     public async create(
         productId: number,
         customFieldData: NoIdProductCustomField,
-        options?: { schema?: StandardSchemaV1 },
+        options?: { schema?: StandardSchemaV1; retries?: RetryConfig },
     ): ApiResult<ProductCustomField> {
         const idsValidOrErrorMsg = validatePositiveIntegers({ productId });
 
@@ -94,7 +86,13 @@ export default class ProductCustomFields {
 
         const url = `${this.apiUrl}/${productId}/custom-fields`;
 
-        return await createResource(url, this.accessToken, customFieldData, options?.schema);
+        return await createResource(
+            url,
+            this.accessToken,
+            customFieldData,
+            options?.schema,
+            options?.retries,
+        );
     }
 
     /* ------------------------ GET PRODUCT CUSTOM FIELDS ----------------------- */
@@ -121,6 +119,7 @@ export default class ProductCustomFields {
             page?: number;
             limit?: number;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<Pick<ProductCustomField, 'id' | I[number]>[]>;
 
@@ -132,6 +131,7 @@ export default class ProductCustomFields {
             page?: number;
             limit?: number;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<Omit<ProductCustomField, E[number]>[]>;
 
@@ -141,6 +141,7 @@ export default class ProductCustomFields {
             page?: number;
             limit?: number;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<ProductCustomField[]>;
 
@@ -152,6 +153,7 @@ export default class ProductCustomFields {
             page?: number;
             limit?: number;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<ProductCustomField[]> {
         const idsValidOrErrorMsg = validatePositiveIntegers({ productId });
@@ -175,6 +177,7 @@ export default class ProductCustomFields {
             limit,
             queryOptions?.page,
             schema,
+            options?.retries,
         );
     }
 
@@ -200,6 +203,7 @@ export default class ProductCustomFields {
             include_fields: I;
             exclude_fields?: never;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<Pick<ProductCustomField, 'id' | I[number]>>;
 
@@ -210,8 +214,15 @@ export default class ProductCustomFields {
             include_fields?: never;
             exclude_fields: E;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<Omit<ProductCustomField, E[number]>>;
+
+    public async getOne(
+        productId: number,
+        customFieldId: number,
+        options?: { schema?: StandardSchemaV1; retries?: RetryConfig },
+    ): ApiResult<ProductCustomField>;
 
     public async getOne(
         productId: number,
@@ -220,6 +231,7 @@ export default class ProductCustomFields {
             include_fields?: readonly ProductCustomFieldField[];
             exclude_fields?: readonly ProductCustomFieldField[];
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<ProductCustomField> {
         const idsValidOrErrorMsg = validatePositiveIntegers({ customFieldId, productId });
@@ -236,7 +248,7 @@ export default class ProductCustomFields {
         const querySuffix = buildQueryString(queryOptions);
         const url = `${this.apiUrl}/${productId}/custom-fields/${customFieldId}${querySuffix}`;
 
-        return await fetchOne<ProductCustomField>(url, this.accessToken, schema);
+        return await fetchOne<ProductCustomField>(url, this.accessToken, schema, options?.retries);
     }
 
     /* ----------------------- UPDATE PRODUCT CUSTOM FIELD ---------------------- */
@@ -248,13 +260,14 @@ export default class ProductCustomFields {
      * @param customFieldData - The partial custom field data to update.
      * @param options - Optional. Pass `schema` to validate the returned data against a Standard Schema.
      * @param options.schema - A Standard Schema to validate the API response against. If validation fails, the method will return a 422 error with details about the validation failure.
+     * @param options.retries - Optional retry configuration to automatically retry the request on transient errors.
      * @returns {ApiResult<ProductCustomField>} The result of the update operation.
      */
     public async update(
         productId: number,
         customFieldId: number,
         customFieldData: Partial<NoIdProductCustomField>,
-        options?: { schema?: StandardSchemaV1 },
+        options?: { schema?: StandardSchemaV1; retries?: RetryConfig },
     ): ApiResult<ProductCustomField> {
         const idsValidOrErrorMsg = validatePositiveIntegers({ customFieldId, productId });
 
@@ -278,7 +291,13 @@ export default class ProductCustomFields {
 
         const url = `${this.apiUrl}/${productId}/custom-fields/${customFieldId}`;
 
-        return await updateResource(url, this.accessToken, customFieldData, options?.schema);
+        return await updateResource(
+            url,
+            this.accessToken,
+            customFieldData,
+            options?.schema,
+            options?.retries,
+        );
     }
 
     /* ----------------------- DELETE PRODUCT CUSTOM FIELD ---------------------- */
@@ -287,9 +306,15 @@ export default class ProductCustomFields {
      *
      * @param productId - The ID of the product.
      * @param customFieldId - The ID of the custom field to remove.
+     * @param options - Optional parameters for the request.
+     * @param options.retries - Optional retry configuration to automatically retry the request on transient errors.
      * @returns {ApiResult<null>} The result of the remove operation.
      */
-    public async remove(productId: number, customFieldId: number): ApiResult<null> {
+    public async remove(
+        productId: number,
+        customFieldId: number,
+        options?: { retries?: RetryConfig },
+    ): ApiResult<null> {
         const idsValidOrErrorMsg = validatePositiveIntegers({ customFieldId, productId });
 
         if (idsValidOrErrorMsg !== true) {
@@ -302,7 +327,7 @@ export default class ProductCustomFields {
 
         const url = `${this.apiUrl}/${productId}/custom-fields/${customFieldId}`;
 
-        return await deleteResource(url, this.accessToken);
+        return await deleteResource(url, this.accessToken, options?.retries);
     }
 
     /* -------------------------------------------------------------------------- */

--- a/src/v3Api/Products/ProductImages.ts
+++ b/src/v3Api/Products/ProductImages.ts
@@ -11,7 +11,7 @@ import {
     validatePositiveIntegers,
 } from '@/v3Api/utils';
 
-import type { ApiResult, BcApiChefOptions, StandardSchemaV1 } from '@/types/api-types';
+import type { ApiResult, RetryConfig, StandardSchemaV1 } from '@/types/api-types';
 import type {
     ApiImageQueryBase,
     BaseProductImageField,
@@ -35,22 +35,14 @@ import type {
 export default class ProductImages {
     private accessToken: string;
     private apiUrl: string;
-    private options: Required<BcApiChefOptions>;
 
     /**
      * @param accessToken BigCommerce API access token.
      * @param apiUrl Base URL for product images endpoint.
-     * @param options Optional configuration for API requests, such as retries.
-     * @param options.retries Number of times to retry a failed HTTP request before surfacing the error. Forwarded to the underlying `tchef` HTTP client. Defaults to `0` (no retries).
-     * @todo Forward `this.options.retries` to every `tchef()` call in this class.
      */
-    constructor(accessToken: string, apiUrl: string, options?: BcApiChefOptions) {
+    constructor(accessToken: string, apiUrl: string) {
         this.accessToken = accessToken;
         this.apiUrl = apiUrl;
-        this.options = {
-            retries: 0,
-            ...options,
-        };
     }
 
     /* -------------------------------------------------------------------------- */
@@ -69,7 +61,7 @@ export default class ProductImages {
     public async create(
         productId: number,
         imageData: ProductImagePayloadItem,
-        options?: { schema?: StandardSchemaV1 },
+        options?: { schema?: StandardSchemaV1; retries?: RetryConfig },
     ): ApiResult<ProductImage> {
         const idValidOrError = validatePositiveIntegers({ productId });
 
@@ -111,10 +103,17 @@ export default class ProductImages {
                 this.accessToken,
                 formData,
                 options?.schema,
+                options?.retries,
             );
         }
 
-        return await createResource(url, this.accessToken, imageData, options?.schema);
+        return await createResource(
+            url,
+            this.accessToken,
+            imageData,
+            options?.schema,
+            options?.retries,
+        );
     }
 
     /* ------------------------------- GET IMAGES ------------------------------- */
@@ -137,6 +136,7 @@ export default class ProductImages {
             include_fields: I;
             exclude_fields?: never;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<Pick<ProductImage, 'id' | I[number]>[]>;
 
@@ -146,12 +146,13 @@ export default class ProductImages {
             include_fields?: never;
             exclude_fields: E;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<Omit<ProductImage, E[number]>[]>;
 
     public async getMultiple(
         productId: number,
-        options?: ApiImageQueryBase & { schema?: StandardSchemaV1 },
+        options?: ApiImageQueryBase & { schema?: StandardSchemaV1; retries?: RetryConfig },
     ): ApiResult<ProductImage[]>;
 
     public async getMultiple(
@@ -160,6 +161,7 @@ export default class ProductImages {
             include_fields?: readonly BaseProductImageField[];
             exclude_fields?: readonly BaseProductImageField[];
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<ProductImage[]> {
         const idValidOrError = validatePositiveIntegers({ productId });
@@ -183,6 +185,7 @@ export default class ProductImages {
             limit,
             queryOptions?.page,
             schema,
+            options?.retries,
         );
     }
 
@@ -204,19 +207,29 @@ export default class ProductImages {
     public async getOne<I extends readonly BaseProductImageField[]>(
         productId: number,
         imageId: number,
-        options: { include_fields: I; exclude_fields?: never; schema?: StandardSchemaV1 },
+        options: {
+            include_fields: I;
+            exclude_fields?: never;
+            schema?: StandardSchemaV1;
+            retries?: RetryConfig;
+        },
     ): ApiResult<Pick<ProductImage, 'id' | I[number]>>;
 
     public async getOne<E extends readonly BaseProductImageField[]>(
         productId: number,
         imageId: number,
-        options: { include_fields?: never; exclude_fields: E; schema?: StandardSchemaV1 },
+        options: {
+            include_fields?: never;
+            exclude_fields: E;
+            schema?: StandardSchemaV1;
+            retries?: RetryConfig;
+        },
     ): ApiResult<Omit<ProductImage, E[number]>>;
 
     public async getOne(
         productId: number,
         imageId: number,
-        options?: { schema?: StandardSchemaV1 },
+        options?: { schema?: StandardSchemaV1; retries?: RetryConfig },
     ): ApiResult<ProductImage>;
 
     public async getOne(
@@ -226,6 +239,7 @@ export default class ProductImages {
             include_fields?: readonly BaseProductImageField[];
             exclude_fields?: readonly BaseProductImageField[];
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<ProductImage> {
         const idsValidOrErrorMsg = validatePositiveIntegers({ imageId, productId });
@@ -238,7 +252,7 @@ export default class ProductImages {
         const querySuffix = buildQueryString(queryOptions);
         const url = `${this.apiUrl}/${productId}/images/${imageId}${querySuffix}`;
 
-        return await fetchOne<ProductImage>(url, this.accessToken, schema);
+        return await fetchOne<ProductImage>(url, this.accessToken, schema, options?.retries);
     }
 
     /* ------------------------------- UPDATE IMAGE ------------------------------ */
@@ -256,7 +270,7 @@ export default class ProductImages {
         productId: number,
         imageId: number,
         imageData: ProductImageUpdatePayload,
-        options?: { schema?: StandardSchemaV1 },
+        options?: { schema?: StandardSchemaV1; retries?: RetryConfig },
     ): ApiResult<ProductImage> {
         const idsValidOrErrorMsg = validatePositiveIntegers({ imageId, productId });
 
@@ -297,10 +311,17 @@ export default class ProductImages {
                 this.accessToken,
                 formData,
                 options?.schema,
+                options?.retries,
             );
         }
 
-        return await updateResource(url, this.accessToken, imageData, options?.schema);
+        return await updateResource(
+            url,
+            this.accessToken,
+            imageData,
+            options?.schema,
+            options?.retries,
+        );
     }
 
     /* ------------------------------- DELETE IMAGE ------------------------------ */
@@ -309,9 +330,15 @@ export default class ProductImages {
      *
      * @param productId ID of the product the image belongs to.
      * @param imageId ID of the image to delete.
+     * @param options Optional parameters for the request.
+     * @param options.retries - Optional retry configuration to automatically retry the request on transient errors.
      * @returns {ApiResult<null>} An empty result on success or an error result.
      */
-    public async remove(productId: number, imageId: number): ApiResult<null> {
+    public async remove(
+        productId: number,
+        imageId: number,
+        options?: { retries?: RetryConfig },
+    ): ApiResult<null> {
         const idsValidOrErrorMsg = validatePositiveIntegers({ imageId, productId });
 
         if (idsValidOrErrorMsg !== true) {
@@ -324,7 +351,7 @@ export default class ProductImages {
 
         const url = `${this.apiUrl}/${productId}/images/${imageId}`;
 
-        return await deleteResource(url, this.accessToken);
+        return await deleteResource(url, this.accessToken, options?.retries);
     }
 
     /* -------------------------------------------------------------------------- */

--- a/src/v3Api/Products/ProductMetafields.ts
+++ b/src/v3Api/Products/ProductMetafields.ts
@@ -9,7 +9,7 @@ import {
     validatePositiveIntegers,
 } from '@/v3Api/utils.ts';
 
-import type { ApiResult, BcApiChefOptions, StandardSchemaV1 } from '@/types/api-types';
+import type { ApiResult, RetryConfig, StandardSchemaV1 } from '@/types/api-types';
 import type {
     ApiMetafieldQueryBase,
     BaseMetafieldField,
@@ -32,23 +32,14 @@ import type {
 export default class ProductMetafields {
     private accessToken: string;
     private apiUrl: string;
-    private options: Required<BcApiChefOptions>;
 
     /**
      * @param accessToken BigCommerce API access token, sent as `X-Auth-Token` on every request.
      * @param apiUrl Base metafields API URL, already scoped to `catalog/products/{productId}/metafields`.
-     * @param options Shared client options propagated from `BcApiChef`.
-     * `retries` is reserved for retry support in downstream HTTP calls.
-     * @param options.retries Number of times to retry a failed HTTP request before surfacing the error. Forwarded to the underlying `tchef` HTTP client. Defaults to `0` (no retries).
-     * @todo Forward `this.options.retries` to every `tchef()` call in this class.
      */
-    constructor(accessToken: string, apiUrl: string, options: BcApiChefOptions = {}) {
+    constructor(accessToken: string, apiUrl: string) {
         this.accessToken = accessToken;
         this.apiUrl = apiUrl;
-        this.options = {
-            retries: 0,
-            ...options,
-        };
     }
 
     /* -------------------------------------------------------------------------- */
@@ -67,7 +58,7 @@ export default class ProductMetafields {
     public async create(
         productId: number,
         metafieldData: CreateMetafieldPayload,
-        options?: { schema?: StandardSchemaV1 },
+        options?: { schema?: StandardSchemaV1; retries?: RetryConfig },
     ): ApiResult<ProductMetafield> {
         const idValidOrError = validatePositiveIntegers({ productId });
 
@@ -87,7 +78,13 @@ export default class ProductMetafields {
 
         const url = `${this.apiUrl}/${productId}/metafields`;
 
-        return await createResource(url, this.accessToken, metafieldData, options?.schema);
+        return await createResource(
+            url,
+            this.accessToken,
+            metafieldData,
+            options?.schema,
+            options?.retries,
+        );
     }
 
     /* ----------------------------- GET METAFIELDS ----------------------------- */
@@ -109,6 +106,7 @@ export default class ProductMetafields {
             include_fields: I;
             exclude_fields?: never;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<Pick<ProductMetafield, 'id' | I[number]>[]>;
 
@@ -118,12 +116,13 @@ export default class ProductMetafields {
             include_fields?: never;
             exclude_fields: E;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<Omit<ProductMetafield, E[number]>[]>;
 
     public async getMultiple(
         productId: number,
-        options?: ApiMetafieldQueryBase & { schema?: StandardSchemaV1 },
+        options?: ApiMetafieldQueryBase & { schema?: StandardSchemaV1; retries?: RetryConfig },
     ): ApiResult<ProductMetafield[]>;
 
     public async getMultiple(
@@ -132,6 +131,7 @@ export default class ProductMetafields {
             include_fields?: readonly BaseMetafieldField[];
             exclude_fields?: readonly BaseMetafieldField[];
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<ProductMetafield[]> {
         const idValidOrErrorMsg = validatePositiveIntegers({ productId });
@@ -151,6 +151,7 @@ export default class ProductMetafields {
             limit,
             queryOptions?.page,
             schema,
+            options?.retries,
         );
     }
 
@@ -172,19 +173,29 @@ export default class ProductMetafields {
     public async getOne(
         productId: number,
         metafieldId: number,
-        options?: { schema?: StandardSchemaV1 },
+        options?: { schema?: StandardSchemaV1; retries?: RetryConfig },
     ): ApiResult<ProductMetafield>;
 
     public async getOne<I extends readonly BaseMetafieldField[]>(
         productId: number,
         metafieldId: number,
-        options: { include_fields: I; exclude_fields?: never; schema?: StandardSchemaV1 },
+        options: {
+            include_fields: I;
+            exclude_fields?: never;
+            schema?: StandardSchemaV1;
+            retries?: RetryConfig;
+        },
     ): ApiResult<Pick<ProductMetafield, 'id' | I[number]>>;
 
     public async getOne<E extends readonly BaseMetafieldField[]>(
         productId: number,
         metafieldId: number,
-        options: { include_fields?: never; exclude_fields: E; schema?: StandardSchemaV1 },
+        options: {
+            include_fields?: never;
+            exclude_fields: E;
+            schema?: StandardSchemaV1;
+            retries?: RetryConfig;
+        },
     ): ApiResult<Omit<ProductMetafield, E[number]>>;
 
     public async getOne(
@@ -194,6 +205,7 @@ export default class ProductMetafields {
             include_fields?: readonly BaseMetafieldField[];
             exclude_fields?: readonly BaseMetafieldField[];
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<ProductMetafield> {
         const idsValidOrErrorMsg = validatePositiveIntegers({ metafieldId, productId });
@@ -206,7 +218,7 @@ export default class ProductMetafields {
         const querySuffix = buildQueryString(queryOptions);
         const url = `${this.apiUrl}/${productId}/metafields/${metafieldId}${querySuffix}`;
 
-        return await fetchOne<ProductMetafield>(url, this.accessToken, schema);
+        return await fetchOne<ProductMetafield>(url, this.accessToken, schema, options?.retries);
     }
 
     /* ----------------------------- UPDATE METAFIELD ---------------------------- */
@@ -217,13 +229,14 @@ export default class ProductMetafields {
      * @param metafieldData Metafield data to update.
      * @param options Optional parameters for the request.
      * @param options.schema - A Standard Schema to validate the API response against. If validation fails, the method will return a 422 error with details about the validation failure.
+     * @param options.retries - Optional retry configuration to automatically retry the request on transient errors.
      * @returns {ApiResult<ProductMetafield>} The updated metafield or an error result.
      */
     public async update(
         productId: number,
         metafieldId: number,
         metafieldData: Partial<CreateMetafieldPayload>,
-        options?: { schema?: StandardSchemaV1 },
+        options?: { schema?: StandardSchemaV1; retries?: RetryConfig },
     ): ApiResult<ProductMetafield> {
         const idsValidOrErrorMsg = validatePositiveIntegers({ metafieldId, productId });
 
@@ -243,16 +256,28 @@ export default class ProductMetafields {
 
         const url = `${this.apiUrl}/${productId}/metafields/${metafieldId}`;
 
-        return await updateResource(url, this.accessToken, metafieldData, options?.schema);
+        return await updateResource(
+            url,
+            this.accessToken,
+            metafieldData,
+            options?.schema,
+            options?.retries,
+        );
     }
 
     /**
      * Deletes a metafield by product and metafield ID.
      * @param productId Product ID.
      * @param metafieldId Metafield ID.
+     * @param options Optional parameters for the request.
+     * @param options.retries - Optional retry configuration to automatically retry the request on transient errors.
      * @returns {ApiResult<null>} `null` on success or an error result.
      */
-    public async remove(productId: number, metafieldId: number): ApiResult<null> {
+    public async remove(
+        productId: number,
+        metafieldId: number,
+        options?: { retries?: RetryConfig },
+    ): ApiResult<null> {
         const idsValidOrErrorMsg = validatePositiveIntegers({ metafieldId, productId });
 
         if (idsValidOrErrorMsg !== true) {
@@ -265,7 +290,7 @@ export default class ProductMetafields {
 
         const url = `${this.apiUrl}/${productId}/metafields/${metafieldId}`;
 
-        return await deleteResource(url, this.accessToken);
+        return await deleteResource(url, this.accessToken, options?.retries);
     }
 
     /* -------------------------------------------------------------------------- */

--- a/src/v3Api/Products/Products.ts
+++ b/src/v3Api/Products/Products.ts
@@ -14,7 +14,7 @@ import ProductCustomFields from './ProductCustomFields';
 import ProductImages from './ProductImages';
 import ProductMetafields from './ProductMetafields';
 
-import type { ApiResult, BcApiChefOptions, StandardSchemaV1 } from '@/types/api-types';
+import type { ApiResult, RetryConfig, StandardSchemaV1 } from '@/types/api-types';
 import type {
     ApiGetProductQueryBase,
     ApiProductQuery,
@@ -50,28 +50,16 @@ import type {
 export default class ProductsV3 {
     private accessToken: string;
     private apiUrl: string;
-    /** The `Required` here makes typescript happy without having to check for undefined values upstream constantly, but the values are still optional at runtime */
-    private options: Required<BcApiChefOptions>;
     private readonly productsApiPath = 'catalog/products';
 
     /**
      * @param baseUrlWithVersion - Store base URL including the `/v3` version segment.
      * @param accessToken - BigCommerce API access token, sent as `X-Auth-Token`
      * on every request.
-     * @param options - Shared client options propagated from `BcApiChef`.
-     * `retries` is reserved for retry support in downstream HTTP calls.
-     * @param options.retries  - Number of times to retry a failed HTTP request before
-     * surfacing the error. Forwarded to the underlying `tchef` HTTP client.
-     * Defaults to `0` (no retries).
-     * @todo Forward `this.options.retries` to every `tchef()` call in this class.
      */
-    constructor(baseUrlWithVersion: string, accessToken: string, options: BcApiChefOptions = {}) {
+    constructor(baseUrlWithVersion: string, accessToken: string) {
         this.accessToken = accessToken;
         this.apiUrl = `${baseUrlWithVersion}/${this.productsApiPath}`;
-        this.options = {
-            retries: 0,
-            ...options,
-        };
     }
 
     /* -------------------------------------------------------------------------- */
@@ -92,17 +80,21 @@ export default class ProductsV3 {
      */
     public async create<F extends readonly NoIdProductField[]>(
         productData: CreateProductPayload,
-        options: { include_fields: F; schema?: StandardSchemaV1 },
+        options: { include_fields: F; schema?: StandardSchemaV1; retries?: RetryConfig },
     ): ApiResult<CreateProductReturnType<F>>;
 
     public async create(
         productData: CreateProductPayload,
-        options?: { schema?: StandardSchemaV1 },
+        options?: { schema?: StandardSchemaV1; retries?: RetryConfig },
     ): ApiResult<BaseProduct>;
 
     public async create(
         productData: CreateProductPayload,
-        options?: { include_fields?: readonly NoIdProductField[]; schema?: StandardSchemaV1 },
+        options?: {
+            include_fields?: readonly NoIdProductField[];
+            schema?: StandardSchemaV1;
+            retries?: RetryConfig;
+        },
     ): ApiResult<BaseProduct> {
         const validationError = this.validateCreateProductPayload(productData);
 
@@ -115,7 +107,7 @@ export default class ProductsV3 {
         const querySuffix = buildQueryString(queryOptions);
         const url = `${this.apiUrl}${querySuffix}`;
 
-        return await createResource(url, this.accessToken, productData, schema);
+        return await createResource(url, this.accessToken, productData, schema, options?.retries);
     }
 
     /* ------------------------------ GET PRODUCTS ------------------------------ */
@@ -143,6 +135,7 @@ export default class ProductsV3 {
             include_fields: F;
             exclude_fields?: never;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<ProductWithFields<F, T>[]>;
 
@@ -155,6 +148,7 @@ export default class ProductsV3 {
             include_fields?: never;
             exclude_fields: E;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<ProductWithoutFields<E, T>[]>;
 
@@ -162,6 +156,7 @@ export default class ProductsV3 {
         options?: ApiProductQueryBase & {
             includes?: T & ProductIncludes;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<(BaseProduct & IncludeExpansion<T>)[]>;
 
@@ -171,6 +166,7 @@ export default class ProductsV3 {
             include_fields?: readonly NoIdProductField[];
             exclude_fields?: readonly NoIdProductField[];
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<BaseProduct[]> {
         const { includes, schema, ...query } = options ?? {};
@@ -184,6 +180,7 @@ export default class ProductsV3 {
             clampPerPageLimits(query?.limit),
             query?.page,
             schema,
+            options?.retries,
         );
     }
 
@@ -212,6 +209,7 @@ export default class ProductsV3 {
             include_fields: F;
             exclude_fields?: never;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<ProductWithFields<F, T>>;
 
@@ -225,6 +223,7 @@ export default class ProductsV3 {
             include_fields?: never;
             exclude_fields: E;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<ProductWithoutFields<E, T>>;
 
@@ -233,6 +232,7 @@ export default class ProductsV3 {
         options?: ApiGetProductQueryBase & {
             includes?: T & ProductIncludes;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<BaseProduct & IncludeExpansion<T>>;
 
@@ -243,6 +243,7 @@ export default class ProductsV3 {
             include_fields?: readonly NoIdProductField[];
             exclude_fields?: readonly NoIdProductField[];
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<BaseProduct> {
         const idValidOrErrorMsg = validatePositiveIntegers({ productId });
@@ -256,7 +257,7 @@ export default class ProductsV3 {
         const querySuffix = buildQueryString(query as ApiProductQuery, { include: includesString });
         const url = `${this.apiUrl}/${productId}${querySuffix}`;
 
-        return await fetchOne<FullProduct>(url, this.accessToken, schema);
+        return await fetchOne<FullProduct>(url, this.accessToken, schema, options?.retries);
     }
 
     /* ------------------------------ UPDATE PRODUCT ------------------------------ */
@@ -283,6 +284,7 @@ export default class ProductsV3 {
             includes?: T & ProductIncludes;
             include_fields: F;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<ProductWithFields<F, T>>;
 
@@ -292,6 +294,7 @@ export default class ProductsV3 {
         options?: {
             includes?: T & ProductIncludes;
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<BaseProduct & IncludeExpansion<T>>;
 
@@ -302,6 +305,7 @@ export default class ProductsV3 {
             includes?: ProductIncludes;
             include_fields?: readonly NoIdProductField[];
             schema?: StandardSchemaV1;
+            retries?: RetryConfig;
         },
     ): ApiResult<BaseProduct> {
         const idValidOrErrorMsg = validatePositiveIntegers({ productId });
@@ -321,16 +325,18 @@ export default class ProductsV3 {
         const querySuffix = buildQueryString(query as ApiProductQuery, { include: includesString });
         const url = `${this.apiUrl}/${productId}${querySuffix}`;
 
-        return await updateResource(url, this.accessToken, payload, schema);
+        return await updateResource(url, this.accessToken, payload, schema, options?.retries);
     }
 
     /* ------------------------------ DELETE PRODUCT ------------------------------ */
     /**
      * Deletes a product by ID.
      * @param productId Product ID.
+     * @param options Optional parameters.
+     * @param options.retries - Optional retry configuration to automatically retry the request on transient errors.
      * @returns {ApiResult<null>} `null` on success or an error result.
      */
-    public async remove(productId: number): ApiResult<null> {
+    public async remove(productId: number, options?: { retries?: RetryConfig }): ApiResult<null> {
         const idValidOrErrorMsg = validatePositiveIntegers({ productId });
 
         if (idValidOrErrorMsg !== true) {
@@ -339,7 +345,7 @@ export default class ProductsV3 {
 
         const url = `${this.apiUrl}/${productId}`;
 
-        return await deleteResource(url, this.accessToken);
+        return await deleteResource(url, this.accessToken, options?.retries);
     }
 
     /* -------------------------------------------------------------------------- */
@@ -351,7 +357,7 @@ export default class ProductsV3 {
      * @returns {ProductBulkPricingRules} An instance of the ProductBulkPricingRules class.
      */
     public bulkPricingRules(): ProductBulkPricingRules {
-        return new ProductBulkPricingRules(this.accessToken, this.apiUrl, this.options);
+        return new ProductBulkPricingRules(this.accessToken, this.apiUrl);
     }
 
     /**
@@ -359,7 +365,7 @@ export default class ProductsV3 {
      * @returns {ProductCustomFields} An instance of the ProductCustomFields class.
      */
     public customFields(): ProductCustomFields {
-        return new ProductCustomFields(this.accessToken, this.apiUrl, this.options);
+        return new ProductCustomFields(this.accessToken, this.apiUrl);
     }
 
     /**
@@ -367,7 +373,7 @@ export default class ProductsV3 {
      * @returns {ProductImages} An instance of the ProductImages class.
      */
     public images(): ProductImages {
-        return new ProductImages(this.accessToken, this.apiUrl, this.options);
+        return new ProductImages(this.accessToken, this.apiUrl);
     }
 
     /**
@@ -375,7 +381,7 @@ export default class ProductsV3 {
      * @returns {ProductMetafields} An instance of the ProductMetafields class.
      */
     public metafields(): ProductMetafields {
-        return new ProductMetafields(this.accessToken, this.apiUrl, this.options);
+        return new ProductMetafields(this.accessToken, this.apiUrl);
     }
 
     /* -------------------------------------------------------------------------- */

--- a/src/v3Api/V3Api.ts
+++ b/src/v3Api/V3Api.ts
@@ -1,15 +1,12 @@
 import ProductsV3 from './Products/Products.ts';
 
-import type { BcApiChefOptions } from '@/types/api-types';
-
 /**
  * Fluent builder for BigCommerce's `/v3` API namespace.
  *
  * Not intended to be instantiated directly by package consumers — use
  * {@link BcApiChef.v3} to obtain a correctly-configured instance. Each call
  * to a sub-resource method (currently only {@link V3Api.products}) returns a
- * fresh endpoint wrapper sharing the same access token, base URL, and
- * forwarded options.
+ * fresh endpoint wrapper sharing the same access token and base URL.
  *
  * Scope today: `catalog/products` only. The class is structured to scale to
  * additional V3 endpoint families (brands, categories, customers, etc.) as
@@ -19,38 +16,26 @@ export default class V3Api {
     private accessToken: string;
     private baseUrl: string;
     private baseUrlWithVersion: string;
-    /** The `Required` here makes typescript happy without having to check for undefined values upstream constantly, but the values are still optional at runtime */
-    private options: Required<BcApiChefOptions>;
     private readonly version = 'v3';
 
     /**
      * @param baseUrl - Store base URL (`https://api.bigcommerce.com/stores/{hash}`),
      * without the API version segment.
      * @param accessToken - BigCommerce API access token, forwarded to every request.
-     * @param options - Shared client options propagated from `BcApiChef`.
-     * `retries` is reserved for retry support in downstream HTTP calls.
-     * @param options.retries  - Number of times to retry a failed HTTP request before
-     * surfacing the error. Forwarded to the underlying `tchef` HTTP client.
-     * Defaults to `0` (no retries).
-     * @todo `retries` is not yet forwarded to `tchef()` by `ProductsV3`.
      */
-    constructor(baseUrl: string, accessToken: string, options: BcApiChefOptions = {}) {
+    constructor(baseUrl: string, accessToken: string) {
         this.accessToken = accessToken;
         this.baseUrl = baseUrl;
         this.baseUrlWithVersion = `${this.baseUrl}/${this.version}`;
-        this.options = {
-            retries: 0,
-            ...options,
-        };
     }
 
     /**
      * Creates the Products V3 endpoint wrapper for this client.
      * Each call returns a fresh {@link ProductsV3} instance that shares the same
-     * base URL, access token, and client options.
+     * base URL and access token.
      * @returns {ProductsV3} A new `ProductsV3` instance for catalog product operations.
      */
     public products(): ProductsV3 {
-        return new ProductsV3(this.baseUrlWithVersion, this.accessToken, this.options);
+        return new ProductsV3(this.baseUrlWithVersion, this.accessToken);
     }
 }

--- a/src/v3Api/utils.ts
+++ b/src/v3Api/utils.ts
@@ -4,7 +4,7 @@ import { DEFAULT_START_PAGE, PER_PAGE_DEFAULT, PER_PAGE_MAX, PER_PAGE_MIN } from
 
 import type { TchefResult } from 'tchef';
 
-import type { BcRequestResponseMeta, StandardSchemaV1 } from '@/types/api-types';
+import type { BcRequestResponseMeta, RetryConfig, StandardSchemaV1 } from '@/types/api-types';
 
 const PAGINATION_PARAMS = new Set(['page', 'limit']);
 
@@ -38,18 +38,22 @@ async function runSchemaValidation(
  * @param url - Fully-built request URL.
  * @param accessToken - BigCommerce API access token.
  * @param schema - Optional Standard Schema-compliant schema to validate the unwrapped response data at runtime.
+ * @param retryConfig - Optional retry configuration forwarded to tchef.
  * @returns {Promise<TchefResult<T>>} The resource or an error result.
  */
 export async function fetchOne<T>(
     url: string,
     accessToken: string,
     schema?: StandardSchemaV1,
+    retryConfig?: RetryConfig,
 ): Promise<TchefResult<T>> {
     const response = await tchef(url, {
         headers: {
             Accept: 'application/json',
             'X-Auth-Token': accessToken,
         },
+        retries: retryConfig?.repeat,
+        retryDelayMs: retryConfig?.retryDelay,
     });
 
     if (!response.ok) {
@@ -76,14 +80,17 @@ export async function fetchOne<T>(
  * @param limit - Page size (should already be clamped by the caller).
  * @param singlePage - When provided, only that page is fetched and returned.
  * @param schema - Optional Standard Schema-compliant schema to validate each item. Short-circuits on the first failure.
+ * @param retryConfig - Optional retry configuration forwarded to tchef.
  * @returns {Promise<TchefResult<T[]>>} The collected rows or an error result.
  */
+// oxlint-disable-next-line max-params
 export async function fetchPaginated<T>(
     baseUrl: string,
     accessToken: string,
     limit: number,
     singlePage?: number,
     schema?: StandardSchemaV1,
+    retryConfig?: RetryConfig,
 ): Promise<TchefResult<T[]>> {
     const results: T[] = [];
 
@@ -100,6 +107,8 @@ export async function fetchPaginated<T>(
                 Accept: 'application/json',
                 'X-Auth-Token': accessToken,
             },
+            retries: retryConfig?.repeat,
+            retryDelayMs: retryConfig?.retryDelay,
         });
 
         if (!response.ok) {
@@ -135,9 +144,14 @@ export async function fetchPaginated<T>(
  * Sends a `DELETE` request to the specified URL.
  * @param url - Fully-built request URL.
  * @param accessToken - BigCommerce API access token.
+ * @param retryConfig - Optional retry configuration forwarded to tchef.
  * @returns {Promise<TchefResult<null>>} An empty success result or an error result.
  */
-export async function deleteResource(url: string, accessToken: string): Promise<TchefResult<null>> {
+export async function deleteResource(
+    url: string,
+    accessToken: string,
+    retryConfig?: RetryConfig,
+): Promise<TchefResult<null>> {
     const response = await tchef(url, {
         headers: {
             Accept: 'application/json',
@@ -145,6 +159,8 @@ export async function deleteResource(url: string, accessToken: string): Promise<
         },
         method: 'DELETE',
         responseFormat: 'text',
+        retries: retryConfig?.repeat,
+        retryDelayMs: retryConfig?.retryDelay,
     });
 
     if (!response.ok) {
@@ -161,6 +177,7 @@ export async function deleteResource(url: string, accessToken: string): Promise<
  * @param accessToken - BigCommerce API access token.
  * @param payload - Request body to serialize as JSON.
  * @param schema - Optional Standard Schema-compliant schema to validate the unwrapped response data at runtime.
+ * @param retryConfig - Optional retry configuration forwarded to tchef.
  * @returns {Promise<TchefResult<T>>} The created resource or an error result.
  */
 export async function createResource<T, P>(
@@ -168,6 +185,7 @@ export async function createResource<T, P>(
     accessToken: string,
     payload: P,
     schema?: StandardSchemaV1,
+    retryConfig?: RetryConfig,
 ): Promise<TchefResult<T>> {
     const response = await tchef(url, {
         body: JSON.stringify(payload),
@@ -177,6 +195,8 @@ export async function createResource<T, P>(
             'X-Auth-Token': accessToken,
         },
         method: 'POST',
+        retries: retryConfig?.repeat,
+        retryDelayMs: retryConfig?.retryDelay,
     });
 
     if (!response.ok) {
@@ -203,6 +223,7 @@ export async function createResource<T, P>(
  * @param accessToken - BigCommerce API access token.
  * @param formData - The `FormData` body to send.
  * @param schema - Optional Standard Schema-compliant schema to validate the unwrapped response data at runtime.
+ * @param retryConfig - Optional retry configuration forwarded to tchef.
  * @returns {Promise<TchefResult<T>>} The created resource or an error result.
  */
 export async function createResourceMultipart<T>(
@@ -210,6 +231,7 @@ export async function createResourceMultipart<T>(
     accessToken: string,
     formData: FormData,
     schema?: StandardSchemaV1,
+    retryConfig?: RetryConfig,
 ): Promise<TchefResult<T>> {
     const response = await tchef(url, {
         body: formData,
@@ -218,6 +240,8 @@ export async function createResourceMultipart<T>(
             'X-Auth-Token': accessToken,
         },
         method: 'POST',
+        retries: retryConfig?.repeat,
+        retryDelayMs: retryConfig?.retryDelay,
     });
 
     if (!response.ok) {
@@ -243,6 +267,7 @@ export async function createResourceMultipart<T>(
  * @param accessToken - BigCommerce API access token.
  * @param payload - Request body to serialize as JSON.
  * @param schema - Optional Standard Schema-compliant schema to validate the unwrapped response data at runtime.
+ * @param retryConfig - Optional retry configuration forwarded to tchef.
  * @returns {Promise<TchefResult<T>>} The updated resource or an error result.
  */
 export async function updateResource<T, P>(
@@ -250,6 +275,7 @@ export async function updateResource<T, P>(
     accessToken: string,
     payload: P,
     schema?: StandardSchemaV1,
+    retryConfig?: RetryConfig,
 ): Promise<TchefResult<T>> {
     const response = await tchef(url, {
         body: JSON.stringify(payload),
@@ -259,6 +285,8 @@ export async function updateResource<T, P>(
             'X-Auth-Token': accessToken,
         },
         method: 'PUT',
+        retries: retryConfig?.repeat,
+        retryDelayMs: retryConfig?.retryDelay,
     });
 
     if (!response.ok) {
@@ -285,6 +313,7 @@ export async function updateResource<T, P>(
  * @param accessToken - BigCommerce API access token.
  * @param formData - The `FormData` body to send.
  * @param schema - Optional Standard Schema-compliant schema to validate the unwrapped response data at runtime.
+ * @param retryConfig - Optional retry configuration forwarded to tchef.
  * @returns {Promise<TchefResult<T>>} The updated resource or an error result.
  */
 export async function updateResourceMultipart<T>(
@@ -292,6 +321,7 @@ export async function updateResourceMultipart<T>(
     accessToken: string,
     formData: FormData,
     schema?: StandardSchemaV1,
+    retryConfig?: RetryConfig,
 ): Promise<TchefResult<T>> {
     const response = await tchef(url, {
         body: formData,
@@ -300,6 +330,8 @@ export async function updateResourceMultipart<T>(
             'X-Auth-Token': accessToken,
         },
         method: 'PUT',
+        retries: retryConfig?.repeat,
+        retryDelayMs: retryConfig?.retryDelay,
     });
 
     if (!response.ok) {


### PR DESCRIPTION
- Removed BcApiChefOptions from ProductCustomFields, ProductImages, ProductMetafields, Products, and V3Api classes.
- Updated constructors to accept only accessToken and apiUrl parameters.
- Added retry configuration to API methods for create, update, delete, and fetch operations.
- Modified utility functions to support retry logic in HTTP requests.
- Updated documentation to reflect changes in parameters and retry functionality.

Co-authored-by: Copilot <copilot@github.com>